### PR TITLE
Bug/forest name

### DIFF
--- a/qsequoia2/QSEQUOIA2_dockwidget.py
+++ b/qsequoia2/QSEQUOIA2_dockwidget.py
@@ -190,7 +190,6 @@ class Qsequoia2DockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         layout_tab = add_tab(LayoutDesignerWidget(iface=self.iface, parent=self), "mActionNewLayout.svg", "Conception de mise en page")
         tools_tab = add_tab(ToolsDialog(iface=self.iface, parent=self), "processingAlgorithm.svg",  "Outils")
 
-        self.projectChanged.connect(forest_tab.on_project_changed)
         self.projectChanged.connect(table_check_tab.on_project_loaded)
         self.projectChanged.connect(add_data_tab.on_project_changed)
 

--- a/qsequoia2/modules/forest_data/forest_data.py
+++ b/qsequoia2/modules/forest_data/forest_data.py
@@ -1,9 +1,10 @@
 
 from pathlib import Path
+from enum import Enum
 
 # Qgis
 from PyQt5 import uic
-from qgis.PyQt.QtWidgets import QWidget
+from qgis.PyQt.QtWidgets import QWidget, QButtonGroup
 from PyQt5.QtCore import QTimer
 
 # Qsequoia2 
@@ -17,6 +18,12 @@ from .update_forest_name import update_forest_name
 UI_PATH = Path(__file__).parent / 'forest_data.ui'
 FORM_CLASS, _ = uic.loadUiType(str(UI_PATH))
 
+class ForestType(Enum):
+    DOMAINE = "Domaine"
+    MASSIF = "Massif"
+    FORET = "Forêt"
+    BOIS = "Bois"
+
 class ForestDataWidget(QWidget, FORM_CLASS):
     """Classe principale du module Forestdata de Qsequoia2"""
     def __init__(self, iface, parent=None):
@@ -26,16 +33,20 @@ class ForestDataWidget(QWidget, FORM_CLASS):
         self.parent = parent
         self.setupUi(self)
 
+        # --- Radio buttons mapping ---
         self.type = {
-            self.rb_domaine: "Domaine",
-            self.rb_massif: "Massif",
-            self.rb_foret: "Forêt",
-            self.rb_bois: "Bois"
+            self.rb_domaine: ForestType.DOMAINE,
+            self.rb_massif: ForestType.MASSIF,
+            self.rb_foret: ForestType.FORET,
+            self.rb_bois: ForestType.BOIS,
         }
 
+        self.group = QButtonGroup(self)
+        self.group.setExclusive(True)
+        self.group.buttonToggled.connect(self.on_checkbox_toggled)
         for rb in self.type:
             rb.setEnabled(False)
-            rb.toggled.connect(self.on_checkbox_toggled)
+            self.group.addButton(rb)
 
         # nom de la foret changé manuellement
         self.le_forest_name.returnPressed.connect(self._on_forest_name_entered)
@@ -130,46 +141,34 @@ class ForestDataWidget(QWidget, FORM_CLASS):
         self.le_surface_unwooded.setText(str(m.get("surface_unwooded", "")))
 
     def display_forest_name(self):
-
         forest_name = get_project_variable("QS2_forest_name")
-  
-        if not forest_name :
+
+        if not forest_name:
             self.le_forest_name.setText("Séléctionnez un Type de propriété")
             return
-        
-        self.le_forest_name.clear()
+
         self.le_forest_name.setText(str(forest_name))
         prefix = forest_name.split(" ")[0]
-        for cb, label in self.type.items():
-            cb.setChecked(label == prefix)
 
-    def on_checkbox_toggled(self, checked):
+        for rb, ftype in self.type.items():
+            rb.blockSignals(True)
+            rb.setChecked(ftype.value == prefix)
+            rb.blockSignals(False)
+
+    def on_checkbox_toggled(self, button, checked):
+        if not checked:
+            return
 
         seq_dir = get_project_variable("QS2_seq_dir")
         seq_id = get_project_variable("QS2_seq_id")
 
-        if not checked:
+        if not seq_dir or not seq_id:
+            button.setChecked(False)
             return
 
-        if not seq_dir or not seq_id :
-            for rb in self.type:
-                if rb.isChecked():
-                    rb.blockSignals(True)
-                    rb.setChecked(False)
-                    rb.blockSignals(False)
-            return
-        
-        seq_dir = Path(seq_dir)
+        forest_type = self.type.get(button)
+        prefix = forest_type.value if forest_type else ""
 
-        if checked:
-            sender_rb = self.sender()
-            for rb in self.type:
-                if rb != sender_rb and rb.isChecked():
-                    rb.blockSignals(True)
-                    rb.setChecked(False)
-                    rb.blockSignals(False)
-
-        prefix = next((label for rb, label in self.type.items() if rb.isChecked()), "")
         forest_name = update_forest_name(prefix, seq_id)
         self.save_forest_name(forest_name)
 

--- a/qsequoia2/modules/forest_data/forest_data.py
+++ b/qsequoia2/modules/forest_data/forest_data.py
@@ -54,14 +54,14 @@ class ForestDataWidget(QWidget, FORM_CLASS):
         QgsProject.instance().readProject.connect(self._on_project_ready)
 
     def _on_project_ready(self):
+        # Laisser Qgis respirer
+        QTimer.singleShot(0, self._on_project_ready_safe)
+
+    def _on_project_ready_safe(self):
         """Called when QGIS project is fully loaded"""
-
-        messageLog("[FOREST DATA] Project fully loaded", "i")
-
         seq_dir = get_project_variable("QS2_seq_dir")
         if not seq_dir:
-            messageLog("[FOREST DATA] No QS2_seq_dir found", "w")
-            return
+            return # ignore projects that are not Sequoia
 
         self._refresh_metadata(seq_dir)
 

--- a/qsequoia2/modules/forest_data/forest_data.py
+++ b/qsequoia2/modules/forest_data/forest_data.py
@@ -6,6 +6,7 @@ from enum import Enum
 from PyQt5 import uic
 from qgis.PyQt.QtWidgets import QWidget, QButtonGroup
 from PyQt5.QtCore import QTimer
+from qgis.core import QgsProject
 
 # Qsequoia2 
 from ..utils.variable import set_project_variable, get_project_variable
@@ -43,18 +44,26 @@ class ForestDataWidget(QWidget, FORM_CLASS):
 
         self.group = QButtonGroup(self)
         self.group.setExclusive(True)
-        self.group.buttonToggled.connect(self.on_checkbox_toggled)
+        self.group.buttonClicked.connect(self._on_rb_clicked)
         for rb in self.type:
             rb.setEnabled(False)
             self.group.addButton(rb)
 
         # nom de la foret changé manuellement
-        self.le_forest_name.returnPressed.connect(self._on_forest_name_entered)
         self.le_forest_name.editingFinished.connect(self._on_forest_name_entered)
+        QgsProject.instance().readProject.connect(self._on_project_ready)
 
-    def on_project_changed(self, seq_dir, seq_id):
-        # attendre que QGIS ait fini de charger les couches
-        QTimer.singleShot(300, lambda: self._refresh_metadata(seq_dir))
+    def _on_project_ready(self):
+        """Called when QGIS project is fully loaded"""
+
+        messageLog("[FOREST DATA] Project fully loaded", "i")
+
+        seq_dir = get_project_variable("QS2_seq_dir")
+        if not seq_dir:
+            messageLog("[FOREST DATA] No QS2_seq_dir found", "w")
+            return
+
+        self._refresh_metadata(seq_dir)
 
     def _refresh_metadata(self, seq_dir):
         """Reload data and refresh metadata display"""
@@ -87,13 +96,37 @@ class ForestDataWidget(QWidget, FORM_CLASS):
         if not seq_metadata:
             return
 
-        # --- Store ---
         self.export_to_project_variables(seq_metadata, seq_dir)
-
-        # --- Display ---
         self.display_base_metadata(seq_metadata)
-        self.display_forest_name()
-        
+
+        self._init_forest_name()
+    
+    def _init_forest_name(self):
+        """Initialize forest name when project changes"""
+
+        messageLog("[FOREST DATA] start _init_forest_name()")
+        forest_name = get_project_variable("QS2_forest_name")
+
+        messageLog(f"[FOREST DATA] forest_name: {forest_name}")
+        if not forest_name:
+            seq_id = get_project_variable("QS2_seq_id")
+            prefix = ForestType.FORET.value  # default
+            forest_name = update_forest_name(prefix, seq_id)
+
+        self._set_forest_name(forest_name)
+
+    def _set_forest_name(self, forest_name):
+        """Single source of truth"""
+
+        messageLog("[FOREST DATA] start _set_forest_name()")
+        forest_name = (forest_name or "").strip()
+        if not forest_name:
+            return
+
+        set_project_variable("QS2_forest_name", forest_name)
+
+        self.le_forest_name.setText(forest_name)
+
     def _ua_status(self, state):
         if state:
             self.lbl_ua_status.setVisible(False)
@@ -140,46 +173,21 @@ class ForestDataWidget(QWidget, FORM_CLASS):
         self.le_surface_wooded.setText(str(m.get("surface_wooded", "")))
         self.le_surface_unwooded.setText(str(m.get("surface_unwooded", "")))
 
-    def display_forest_name(self):
-        forest_name = get_project_variable("QS2_forest_name")
-
-        if not forest_name:
-            self.le_forest_name.setText("Séléctionnez un Type de propriété")
-            return
-
-        self.le_forest_name.setText(str(forest_name))
-        prefix = forest_name.split(" ")[0]
-
-        for rb, ftype in self.type.items():
-            rb.blockSignals(True)
-            rb.setChecked(ftype.value == prefix)
-            rb.blockSignals(False)
-
-    def on_checkbox_toggled(self, button, checked):
-        if not checked:
-            return
-
-        seq_dir = get_project_variable("QS2_seq_dir")
+    def _on_rb_clicked(self, button):
         seq_id = get_project_variable("QS2_seq_id")
-
-        if not seq_dir or not seq_id:
-            button.setChecked(False)
+        if not seq_id:
             return
 
         forest_type = self.type.get(button)
-        prefix = forest_type.value if forest_type else ""
+        if not forest_type:
+            return
 
-        forest_name = update_forest_name(prefix, seq_id)
-        self.save_forest_name(forest_name)
+        forest_name = update_forest_name(forest_type.value, seq_id)
+        self._set_forest_name(forest_name)
 
     def _on_forest_name_entered(self):
         forest_name = self.le_forest_name.text().strip()
         if not forest_name:
             return
-        self.save_forest_name(forest_name)
 
-    def save_forest_name(self, forest_name):
-
-        set_project_variable("QS2_forest_name", forest_name)
-
-        self.le_forest_name.setText(str(forest_name))
+        self._set_forest_name(forest_name)


### PR DESCRIPTION
Correction du bug d'affiche lié à forest_name.

Le signal projectChanged était connecté au module forest_data et au switch de project.

L'ordre d'éxécution était donc :
- Récupération de la variable `QS2_forest_name` (projet en cours) ;
- Chargement du projet

Or il faut d'abord charger le projet avant de récupérer `QS2_forest_name `. Pour cela le signal `QgsProject.instance().readProject.connect(self._on_project_ready)` est utilisé : quand un projet à finis de charger alors on récupère `QS2_forest_name`  