### PR TITLE
Nettoyage de la boîte de dialogue des variables globales et ajout de variables globales plus modulaires

### DIFF
--- a/qsequoia2/modules/global_settings/global_settings.py
+++ b/qsequoia2/modules/global_settings/global_settings.py
@@ -35,8 +35,8 @@ class GlobalSettingsDialog(QDialog, FORM_CLASS):
 
         # Connections
         self.buttonBox.accepted.connect(self.save_settings)
-        self.stylesButton.clicked.connect(self.select_styles_directory)
-        self.modelsButton.clicked.connect(self.select_models_directory)
+        self.btn_styles_directory.clicked.connect(self.select_styles_directory)
+        self.btn_models_directory.clicked.connect(self.select_models_directory)
         self.btn_add_project_suggestion.clicked.connect(self._on_add_suggestion)
         self.btn_rm_project_suggestion.clicked.connect(self._on_rm_suggestion)
         
@@ -44,20 +44,22 @@ class GlobalSettingsDialog(QDialog, FORM_CLASS):
         self.cb_suggest_enabled.toggled.connect(self.btn_add_project_suggestion.setEnabled)
         self.cb_suggest_enabled.toggled.connect(self.btn_rm_project_suggestion.setEnabled)
 
-
     def load_settings(self):
         styles_dir = get_global_variable("QS2_styles_directory") or ""
-        self.stylesInput.setText(styles_dir)
+        self.le_styles_directory.setText(styles_dir)
 
         models_dir = get_global_variable("QS2_models_directory") or ""
-        self.modelsInput.setText(models_dir)
+        self.le_models_directory.setText(models_dir)
 
-        self.userInput.setText(get_global_variable("QS2_user_full_name") or "")
-        self.orga.setText(get_global_variable("QS2_organisation") or "")
-        self.adress.setText(get_global_variable("QS2_adress_organisation") or "")
-
-        self.open_maps.clicked.connect(lambda: open_maps(self.adress.text()))
-
+        self.le_username.setText(get_global_variable("QS2_username") or "")
+        self.le_organization.setText(get_global_variable("QS2_organization") or "")
+        self.le_address_street.setText(get_global_variable("QS2_address_street") or "")
+        self.le_address_postal_code.setText(get_global_variable("QS2_address_postal_code") or "")
+        self.le_address_city.setText(get_global_variable("QS2_address_city") or "")
+        self.le_phone.setText(get_global_variable("QS2_phone") or "")
+        self.le_email.setText(get_global_variable("QS2_email") or "")
+        self.le_website.setText(get_global_variable("QS2_website") or "")
+    
         suggest_enabled = bool(get_global_variable("QS2_project_suggestions_enabled"))
         self.cb_suggest_enabled.setChecked(suggest_enabled)
         self.list_seq_suggestions.setEnabled(suggest_enabled)
@@ -69,17 +71,19 @@ class GlobalSettingsDialog(QDialog, FORM_CLASS):
             self._add_suggestion(folder)
 
     def save_settings(self):
-        set_global_variable("QS2_styles_directory", self.stylesInput.text())
-        set_global_variable("QS2_models_directory", self.modelsInput.text())
-        set_global_variable("QS2_user_full_name", self.userInput.text())
-        set_global_variable("QS2_adress_organisation", self.adress.text())
-        set_global_variable("QS2_organisation", self.orga.text())
-
+        set_global_variable("QS2_styles_directory", self.le_styles_directory.text())
+        set_global_variable("QS2_models_directory", self.le_models_directory.text())
+        set_global_variable("QS2_username", self.le_username.text())
+        set_global_variable("QS2_organization", self.le_organization.text())
+        set_global_variable("QS2_address_street", self.le_address_street.text())
+        set_global_variable("QS2_address_postal_code", self.le_address_postal_code.text())
+        set_global_variable("QS2_address_city", self.le_address_city.text())
+        set_global_variable("QS2_phone", self.le_phone.text())
+        set_global_variable("QS2_email", self.le_email.text())
+        set_global_variable("QS2_website", self.le_website.text())
 
         suggest_enabled = bool(self.cb_suggest_enabled.isChecked())
-        messageLog(f"suggest_enabled before save: {suggest_enabled}")
         set_global_variable("QS2_project_suggestions_enabled", suggest_enabled)
-        messageLog(f"suggest_enabled after save: {get_global_variable('QS2_project_suggestions_enabled')}")
 
         suggestion = self.list_seq_suggestions
         folders = [str(Path(suggestion.item(i).text()).resolve()) for i in range(suggestion.count())]
@@ -109,7 +113,7 @@ class GlobalSettingsDialog(QDialog, FORM_CLASS):
             )
             return
 
-        self.stylesInput.setText(folder)
+        self.le_styles_directory.setText(folder)
 
     def select_models_directory(self):
         base_path = QgsProject.instance().homePath() or str(Path.home())
@@ -121,7 +125,7 @@ class GlobalSettingsDialog(QDialog, FORM_CLASS):
         )
 
         if folder:
-            self.modelsInput.setText(folder)
+            self.le_models_directory.setText(folder)
 
     def _add_suggestion(self, folder_path):
         folder_path = str(Path(folder_path).resolve())

--- a/qsequoia2/modules/global_settings/global_settings.ui
+++ b/qsequoia2/modules/global_settings/global_settings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>406</width>
-    <height>441</height>
+    <width>496</width>
+    <height>541</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,23 +17,23 @@
    <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="label_style">
+      <widget class="QLabel" name="lbl_styles_directory">
        <property name="text">
         <string>Bibliothèque de styles</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
-      <layout class="QHBoxLayout">
+      <layout class="QHBoxLayout" name="hbox_styles_directory">
        <item>
-        <widget class="QLineEdit" name="stylesInput">
+        <widget class="QLineEdit" name="le_styles_directory">
          <property name="enabled">
           <bool>false</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="stylesButton">
+        <widget class="QPushButton" name="btn_styles_directory">
          <property name="toolTip">
           <string>Open a style folder</string>
          </property>
@@ -45,23 +45,23 @@
       </layout>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_models">
+      <widget class="QLabel" name="lbl_models_directory">
        <property name="text">
         <string>Bibliothèque de modèles</string>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
-      <layout class="QHBoxLayout">
+      <layout class="QHBoxLayout" name="hbox_models_directory">
        <item>
-        <widget class="QLineEdit" name="modelsInput">
+        <widget class="QLineEdit" name="le_models_directory">
          <property name="enabled">
           <bool>false</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="modelsButton">
+        <widget class="QPushButton" name="btn_models_directory">
          <property name="toolTip">
           <string>Open a models folder</string>
          </property>
@@ -73,70 +73,86 @@
       </layout>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label_user">
+      <widget class="QLabel" name="lbl_username">
        <property name="text">
         <string>Utilisateur</string>
        </property>
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QLineEdit" name="userInput">
+      <widget class="QLineEdit" name="le_username">
        <property name="enabled">
         <bool>true</bool>
        </property>
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="lbl_organization">
        <property name="text">
         <string>Organisation</string>
        </property>
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QLineEdit" name="orga"/>
+      <widget class="QLineEdit" name="le_organization"/>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="lbl_address_street">
        <property name="text">
         <string>Adresse</string>
        </property>
       </widget>
      </item>
      <item row="4" column="1">
-      <layout class="QHBoxLayout">
-       <item>
-        <widget class="QLineEdit" name="adress"/>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QToolButton" name="open_maps">
-         <property name="toolTip">
-          <string>Ouvrir dans Maps</string>
-         </property>
-         <property name="text">
-          <string>🌍</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      <widget class="QLineEdit" name="le_address_street"/>
      </item>
      <item row="5" column="0">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="lbl_address_postal_code">
        <property name="text">
-        <string/>
+        <string>Code postal</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLineEdit" name="le_address_postal_code"/>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="lbl_address_city">
+       <property name="text">
+        <string>Commune</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLineEdit" name="le_address_city"/>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="lbl_email">
+       <property name="text">
+        <string>Email</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLineEdit" name="le_email"/>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="lbl_website">
+       <property name="text">
+        <string>Site web</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QLineEdit" name="le_website"/>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLineEdit" name="le_phone"/>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="lbl_phone">
+       <property name="text">
+        <string>Téléphone</string>
        </property>
       </widget>
      </item>
@@ -165,7 +181,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_5">
+      <widget class="QLabel" name="lbl_suggest_enabled">
        <property name="text">
         <string>Rechercher les dossiers Sequoia disponibles</string>
        </property>


### PR DESCRIPTION
Salut @Balrog329,

J'ai nettoyé le dialogue de global setting et rajouté plus de variables pour faciliter le travail dans les templates, nous avons maintenant : 
- `"QS2_styles_directory"`
- `"QS2_models_directory"`
- `"QS2_username"`
- `"QS2_organization"`
- `"QS2_address_street"`
- `"QS2_address_postal_code"`
- `"QS2_address_city"`
- `"QS2_phone"`
- `"QS2_email"`
- `"QS2_website"`

Il faudra prévoir une MAJ des templates en conséquence et bien préciser à nos collaborateur de réinitialiser les variables globales.

J'en ai également profiter pour enlever l'appel à google maps.