### PR TITLE
Toolbox/combine plt rast

### DIFF
--- a/qsequoia2/CHANGELOG.md
+++ b/qsequoia2/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to QSequoia2 will be documented in this file.
 
+## [1.0.10] - 2026-06-23
+
+### Changed
+- Complete refactor of ua_checker module :
+  - Minimal UI 
+  - Coherence check of all descriptive field inside same UG
+  - Auto-select & zoom on UA 
+- New `QS2_surface_soumise` variable based on `DGD_SOUMIS` & `DGD_BOISE` fields
+- Update new aliases to macth new RSequoia2 layer (LIDAR & OCCUPATION)
+
+
 ## [1.0.8] - 2026-04-17
 
 ### Added

--- a/qsequoia2/CHANGELOG.md
+++ b/qsequoia2/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to QSequoia2 will be documented in this file.
 
-## [1.0.10] - 2026-06-23
+## [1.1.0] - 2026-06-23
 
 ### Changed
 - Complete refactor of ua_checker module :

--- a/qsequoia2/CHANGELOG.md
+++ b/qsequoia2/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to QSequoia2 will be documented in this file.
 
+## [1.1.1] - 2026-07-20
+### Added
+- Tool to merge `sequoia2` PLT raster in toolbox
+
+
 ## [1.1.0] - 2026-06-23
 
 ### Changed

--- a/qsequoia2/modules/tools/plt_merger.py
+++ b/qsequoia2/modules/tools/plt_merger.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import processing
+
+from qsequoia2.modules.utils.Qmessage import messageBox, messageBar
+from qsequoia2.modules.utils.seq_config import find_seq_id, seq_layer
+
+
+class PltMerger:
+    def __init__(self, iface, seq_dir, key: str = "plt"):
+        self.iface = iface
+        self.seq_dir = Path(seq_dir)
+        self.meta = seq_layer(key)
+
+    @property
+    def root(self) -> Path:
+        return self.seq_dir / self.meta["path"]
+
+    @property
+    def output(self) -> Path:
+        seq_id = find_seq_id(self.seq_dir)
+        return self.root / f"{seq_id}_{self.meta['filename']}"
+
+    def find_rasters(self) -> list[Path]:
+        if not self.root.is_dir():
+            return []
+
+        pattern = f"*_{self.meta['name']}*.{self.meta['ext']}"
+
+        return sorted(
+            path
+            for path in self.root.glob(pattern)
+            if path != self.output
+        )
+
+    def open_dialog(self) -> None:
+        rasters = self.find_rasters()
+
+        if not rasters:
+            messageBox(
+                self.iface,
+                "Fusion des rasters",
+                "Aucun raster contenant « _PLT » n’a été trouvé.",
+                "i",
+            )
+            return
+
+        result = processing.execAlgorithmDialog(
+            "gdal:merge",
+            {
+                "INPUT": [str(path) for path in rasters],
+                "PCT": False,
+                "SEPARATE": False,
+                "NODATA_INPUT": 0,
+                "NODATA_OUTPUT": 0,
+                "DATA_TYPE": 0,
+                "CREATION_OPTIONS": "COMPRESS=DEFLATE|TILED=YES",
+                "EXTRA": "",
+                "OUTPUT": str(self.output),
+            },
+        )
+
+        if result and self.output.exists():
+            messageBar(
+                self.iface,
+                f"Rasters fusionnés : {self.output}",
+                "s",
+            )

--- a/qsequoia2/modules/tools/tools.py
+++ b/qsequoia2/modules/tools/tools.py
@@ -1,26 +1,23 @@
-from datetime import datetime
 from pathlib import Path
 
-from qgis import processing
-from qgis.core import (
-    QgsProject,
-    QgsVectorFileWriter,
-    QgsProviderRegistry,
+from PyQt5 import uic
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication, QTreeWidgetItem, QWidget
+
+from qsequoia2.modules.tools.plt_merger import PltMerger
+from qsequoia2.modules.tools.ua_cleaner import run_clean_ua
+from qsequoia2.modules.utils.Qmessage import messageBar
+from qsequoia2.modules.utils.variable import (
+    get_global_variable,
+    get_project_variable,
 )
 
-from PyQt5 import uic
-from PyQt5.QtWidgets import QWidget, QTreeWidgetItem, QApplication
-from PyQt5.QtCore import Qt
-
-from qsequoia2.modules.tools.ua_cleaner import run_clean_ua
-from qsequoia2.modules.utils.variable import get_global_variable, get_project_variable
-from qsequoia2.modules.utils.Qmessage import messageBar
 
 UI_PATH = Path(__file__).parent / "tools.ui"
 FORM_CLASS, _ = uic.loadUiType(str(UI_PATH))
 
-class ToolsDialog(QWidget, FORM_CLASS):
 
+class ToolsDialog(QWidget, FORM_CLASS):
     def __init__(self, iface, parent=None):
         super().__init__(parent)
 
@@ -28,43 +25,80 @@ class ToolsDialog(QWidget, FORM_CLASS):
         self.dock = parent
 
         self.setupUi(self)
-
         self._init_tree()
-        
+
     def _init_tree(self):
-
         self.tw_tools.clear()
-        self.tw_tools.setHeaderLabels(["UA Tools"])
+        self.tw_tools.setHeaderLabels(["Outils"])
 
-        clean_item = QTreeWidgetItem(["Nettoyer UA"])
-        clean_item.setData(0, Qt.UserRole, self._run_clean_ua)
+        tools = {
+            "Nettoyer UA": self._run_clean_ua,
+            "Fusionner les rasters PLT": self._open_plt_merge,
+        }
 
-        self.tw_tools.addTopLevelItem(clean_item)
+        for label, callback in tools.items():
+            item = QTreeWidgetItem([label])
+            item.setData(0, Qt.UserRole, callback)
+            self.tw_tools.addTopLevelItem(item)
 
         self.tw_tools.itemDoubleClicked.connect(self._run)
 
-    def _run(self, item):
-        func = item.data(0, Qt.UserRole)
-        if callable(func):
-            func()
+    def _run(self, item, _column=0):
+        callback = item.data(0, Qt.UserRole)
 
-    def _run_clean_ua(self):
+        if callable(callback):
+            callback()
+
+    def _get_seq_dir(self):
         seq_dir = get_project_variable("QS2_seq_dir")
-        style_folder = get_global_variable("QS2_styles_directory")
 
         if not seq_dir:
-            raise RuntimeError("Aucune forêt sélectionnée")
+            messageBar(
+                self.iface,
+                "Aucune forêt sélectionnée.",
+                "w",
+            )
+            return None
+
+        return Path(seq_dir)
+
+    def _open_plt_merge(self):
+        seq_dir = self._get_seq_dir()
+
+        if seq_dir:
+            PltMerger(iface=self.iface,seq_dir=seq_dir).open_dialog()
+
+    def _run_clean_ua(self):
+        seq_dir = self._get_seq_dir()
+
+        if not seq_dir:
+            return
+
+        style_folder = get_global_variable("QS2_styles_directory")
 
         QApplication.setOverrideCursor(Qt.WaitCursor)
-        messageBar(self.iface, "Nettoyage UA en cours...", "i", duration=0)
+        messageBar(
+            self.iface,
+            "Nettoyage UA en cours...",
+            "i",
+            duration=0,
+        )
 
         try:
             backup_path = run_clean_ua(seq_dir, style_folder)
 
-            messageBar(self.iface, f"UA nettoyée. Sauvegarde : {backup_path}", "s")
+            messageBar(
+                self.iface,
+                f"UA nettoyée. Sauvegarde : {backup_path}",
+                "s",
+            )
 
-        except Exception as e:
-            messageBar(self.iface, f"Erreur : {str(e)}", "w")
+        except Exception as error:
+            messageBar(
+                self.iface,
+                f"Erreur : {error}",
+                "w",
+            )
 
         finally:
             QApplication.restoreOverrideCursor()

--- a/qsequoia2/modules/utils/seq_config.py
+++ b/qsequoia2/modules/utils/seq_config.py
@@ -29,7 +29,6 @@ def _safe_urlopen(url, timeout=10):
 
     return urllib.request.urlopen(url, timeout=timeout)
 
-
 def sync_seq_configs(timeout: int = 3) -> None:
     """
     Download latest configs to cache.


### PR DESCRIPTION
Ajout d'un nouvel outil permettant de fusionner les rasters de peuplement d'un dossier.

Contexte :
Il arrive fréquement que la carte de peuplement d'un dossier soit en plusieurs parties. Hors `sequoia2` supporte uniquement une carte des peuplement `MA-FORET_PLT.tif`. Dès que la carte eswxt en plusieurs partie, la fonctionnalité d'import avec le module `add_data` n'est plus utile.

Solution:
Pour évitrer ce problème, il est nécessaire de fussionner les cartes des peuplements et de supprimer les pixels noirs (vide entre les cartes résultant de la fusion).
L'outil `plt-merger` est un wrapper autour de l'outil _raster > fusion_ de QGIS. Il permet par défaut :
- De sélectionner toutes les couches contenant `"_PLT"` et `".tif" `dans le dossier `"3_RASTER"` ;
- De définir les pixels noirs comme des pixels `"noData"` ;
- De nommer le fichier de sortie d'après la config `sequoia2` : `MA-FORET_PLT.tif`

L'UI intégrée de l'outil fusion est utilisée pour permettre aux utilisateurs de modifer des paramètres supplméentaires ci-besoin.
