### PR TITLE
try fix crash, better seq state handling, fix error in paper format s…

### DIFF
--- a/qsequoia2/CHANGELOG.md
+++ b/qsequoia2/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to QSequoia2 will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Prevented native QGIS crashes while switching projects with an open layout designer by using the application-level project lifecycle and blocking re-entrant project loads [#94]
+- Corrected format selection that wasn't taking into account landscape for paper dimension.
+- Better handling of Qsequoia2 state : When manually creating or switching project Qsequoia2 state properly update
+
 ## [1.1.1] - 2026-07-20
 ### Added
 - Tool to merge `sequoia2` PLT raster in toolbox

--- a/qsequoia2/modules/layout_designer/layout_builder.py
+++ b/qsequoia2/modules/layout_designer/layout_builder.py
@@ -18,7 +18,7 @@ from qgis.core import (
 from qgis.PyQt.QtWidgets import QMessageBox
 
 from ..utils.Qmessage import messageBar, messageLog
-from ..utils.variable import get_global_variable, get_project_variable, set_project_variable
+from ..utils.variable import get_project_variable, set_project_variable
 from ..utils.seq_config import seq_field, seq_read
 from .processing import buffer, multipart_to_singleparts
 
@@ -34,13 +34,23 @@ class LayoutBuilder:
         ("A0", (841, 1189)),
     )
 
-    def __init__(self, iface, project, seq_id, layout_cfg, layers, coeff_cadre: float = 0.90):
+    def __init__(
+        self,
+        iface,
+        project,
+        seq_id,
+        layout_cfg,
+        layers,
+        models_dir=None,
+        coeff_cadre: float = 0.95,
+    ):
         self.iface = iface
         self.project = project
         self.seq_id = seq_id
         self.layout = layout_cfg
         self.key = self.layout.key
         self.layers = layers
+        self.models_dir = Path(models_dir) if models_dir else None
         self.coeff_cadre = coeff_cadre
 
     def build(self):
@@ -124,8 +134,12 @@ class LayoutBuilder:
         needed_w = (bbox.width() / scale) * 1000.0
         needed_h = (bbox.height() / scale) * 1000.0
 
-        available_w = (mm[0] - 2 * marge_mm) * self.coeff_cadre
-        available_h = (mm[1] - 2 * marge_mm) * self.coeff_cadre
+        paper_w, paper_h = mm
+        if self._pick_orient(bbox) == "landscape":
+            paper_w, paper_h = paper_h, paper_w
+
+        available_w = (paper_w - 2 * marge_mm) * self.coeff_cadre
+        available_h = (paper_h - 2 * marge_mm) * self.coeff_cadre
 
         return needed_w <= available_w and needed_h <= available_h
 
@@ -160,14 +174,8 @@ class LayoutBuilder:
         return None
 
     def _create_layout_name(self, fmt: str, orient: str):
-        qpt, final_orient = self._find_template(
-            [
-                Path(get_global_variable("QS2_models_directory") or ""),
-                TEMPLATE_DIR,
-            ],
-            fmt,
-            orient,
-        )
+        models_dirs = [self.models_dir] if self.models_dir else [TEMPLATE_DIR]
+        qpt, final_orient = self._find_template(models_dirs, fmt, orient)
 
         messageLog(f"[TEMPLATE] Template trouvé: {qpt} (format={fmt}, orient={final_orient})")
 
@@ -196,7 +204,7 @@ class LayoutBuilder:
         tried = []
 
         for models_dir in models_dirs:
-            if not models_dir.exists():
+            if not models_dir.is_dir():
                 tried.append(f"{models_dir} (absent)")
                 continue
 

--- a/qsequoia2/modules/layout_designer/layout_designer.py
+++ b/qsequoia2/modules/layout_designer/layout_designer.py
@@ -7,7 +7,7 @@ from PyQt5.QtCore import QTimer
 from qgis.core import QgsProject
 
 from ..utils.Qmessage import messageBar, messageLog
-from ..utils.variable import get_project_variable, set_project_variable
+from ..utils.variable import get_global_variable, get_project_variable, set_project_variable
 from .layout_builder import LayoutBuilder
 from .project_builder import ProjectBuilder
 from .project_config_loader import ProjectConfigLoader
@@ -28,6 +28,7 @@ class LayoutDesignerWidget(QWidget, FORM_CLASS):
         self.parent = parent
         self.project = QgsProject.instance()
         self.cfg = ProjectConfigLoader(LAYOUT_CONFIG)      
+        self._project_loading = False
         
         self.setupUi(self)
         self._init_ui()
@@ -46,13 +47,21 @@ class LayoutDesignerWidget(QWidget, FORM_CLASS):
         self.btn_run.clicked.connect(self._accept)
 
     def _accept(self):
+        if self._project_loading:
+            return
+
         seq_id = get_project_variable("QS2_seq_id") or None
         seq_dir = get_project_variable("QS2_seq_dir") or None
+        models_dir = get_global_variable("QS2_models_directory") or None
             
         if not seq_dir:
             messageBar(self.iface, "Aucun répertoire sélectionné", "w")
             return
     
+        self._project_loading = True
+        container = self.parent if self.parent else self
+        container.setEnabled(False)
+
         try:
             project_key = self.combo_project.currentData()
             if not project_key:
@@ -81,13 +90,24 @@ class LayoutDesignerWidget(QWidget, FORM_CLASS):
             if is_sequoia_project or not open_composer:
                 return
 
-            QTimer.singleShot(0, lambda: self._build_layout(project_key, seq_id, ctx.layers))
+            QTimer.singleShot(
+                0,
+                lambda: self._build_layout(
+                    project_key,
+                    seq_id,
+                    ctx.layers,
+                    models_dir,
+                ),
+            )
 
 
         except Exception as e:
             messageBar(self.iface, str(e), "critical", 10)
+        finally:
+            container.setEnabled(True)
+            self._project_loading = False
 
-    def _build_layout(self, project_key, seq_id, layers):
+    def _build_layout(self, project_key, seq_id, layers, models_dir):
         try:
             layout_cfg = self.cfg.get_layout(project_key)
             coeff_cadre = self.dsb_occup.value() / 100
@@ -103,6 +123,7 @@ class LayoutDesignerWidget(QWidget, FORM_CLASS):
                 seq_id=seq_id,
                 layout_cfg=layout_cfg,
                 layers=layers,
+                models_dir=models_dir,
                 coeff_cadre=coeff_cadre,
             ).build()
 

--- a/qsequoia2/modules/utils/qgz_project.py
+++ b/qsequoia2/modules/utils/qgz_project.py
@@ -8,7 +8,7 @@ from qsequoia2.modules.utils.variable import (
     get_qs2_project_variables,
     set_project_variable,
 )
-from .Qmessage import messageBar, messageLog
+from .Qmessage import messageBar
 
 def restore_qs2_project_variables(variables: Optional[dict]) -> None:
     """Restore QS2 project variables into the current QGIS project."""
@@ -18,13 +18,15 @@ def restore_qs2_project_variables(variables: Optional[dict]) -> None:
     for name, value in variables.items():
         set_project_variable(name, value)
 
-def load_project(project, path: Path, variables: Optional[dict] = None) -> None:
-    """Load an existing QGIS project and optionally restore QS2 variables."""
+def load_project(iface, path: Path, variables: Optional[dict] = None) -> None:
+    """Load a project through QGIS and optionally restore QS2 variables."""
     path = Path(path)
     try:
-        ok = project.read(str(path))
+        # This closes project-bound UI, notably layout designers, before the
+        # project is replaced. Direct QgsProject.read() bypasses that cleanup.
+        ok = iface.addProject(str(path))
     except Exception as e:
-        messageLog(f"[load_project] Project read crashed {str(e)}", "w")
+        raise RuntimeError(f"Failed to load project: {path}") from e
 
     if not ok:
         raise RuntimeError(f"Failed to load project: {path}")
@@ -91,7 +93,11 @@ def new_seq_project(
 
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    project.clear()
+    # Use QGIS's complete project lifecycle so stale project-bound widgets are
+    # destroyed before configuring the new project.
+    if not iface.newProject(False):
+        raise RuntimeError(f"Failed to initialize project: {path}")
+
     project.setCrs(QgsCoordinateReferenceSystem(datum))
     project.setFileName(str(path))
     restore_qs2_project_variables(variables)
@@ -121,7 +127,7 @@ def open_seq_project(
 
     path = find_seq_project(seq_id, seq_dir, suffix)
     if path:
-        load_project(project, path, variables)
+        load_project(iface, path, variables)
         return path
 
     return new_seq_project(

--- a/qsequoia2/qsequoia2.py
+++ b/qsequoia2/qsequoia2.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 import os
 
-from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication, Qt, QUrl
+from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication, Qt, QUrl, QTimer
 from qgis.PyQt.QtGui import QIcon, QDesktopServices
 from qgis.PyQt.QtWidgets import QAction
 from qgis.core import *
@@ -42,6 +42,7 @@ class Qsequoia2:
         self.toolbar = None
         self.dockwidget = None
         self.dlg = None
+        self._project_loading = False
 
     def tr(self, message):
         return QCoreApplication.translate('Qsequoia2', message)
@@ -60,6 +61,9 @@ class Qsequoia2:
         self.iface.addPluginToMenu(self.menu, action)
 
         self.actions.append(action)
+
+        self.iface.projectRead.connect(self._schedule_project_status_refresh)
+        self.iface.newProjectCreated.connect(self._schedule_project_status_refresh)
 
         # Fetch Rsequoia2 config
         sync_seq_configs()
@@ -115,29 +119,50 @@ class Qsequoia2:
             self.dockwidget = None
 
     def _on_project_changed(self, seq_dir, seq_id):
-
-        path = open_seq_project(
-            self.project,
-            self.iface,
-            seq_id,
-            seq_dir,
-            suffix = "SEQUOIA",
-            ask_create=True,
-            ask_unsaved=True,
-            preserve_qs2_variables=False
-        )
-
-        if not path:
+        if self._project_loading:
             return
 
-        messageLog(f"[PROJECT] Opened project: {path}")
-        messageBar(self.iface, f"Projet prêt : {seq_id}", level="success")
+        self._project_loading = True
+        dockwidget = self.dockwidget
+        if dockwidget:
+            dockwidget.setEnabled(False)
 
-        set_project_variable("QS2_seq_dir", seq_dir)
-        set_project_variable("QS2_seq_id", seq_id)
+        try:
+            path = open_seq_project(
+                self.project,
+                self.iface,
+                seq_id,
+                seq_dir,
+                suffix="SEQUOIA",
+                ask_create=True,
+                ask_unsaved=True,
+                preserve_qs2_variables=False,
+            )
 
+            if not path:
+                return
+
+            messageLog(f"[PROJECT] Opened project: {path}")
+            messageBar(self.iface, f"Projet prêt : {seq_id}", level="success")
+
+            set_project_variable("QS2_seq_dir", seq_dir)
+            set_project_variable("QS2_seq_id", seq_id)
+
+            if self.dockwidget:
+                self.dockwidget.projectLoaded.emit()
+        finally:
+            if dockwidget:
+                dockwidget.setEnabled(True)
+            self._project_loading = False
+
+    def _schedule_project_status_refresh(self):
+        # Project variables are restored immediately after QGIS emits its
+        # project signal, so read them on the next event-loop iteration.
+        QTimer.singleShot(0, self._refresh_project_status)
+
+    def _refresh_project_status(self):
         if self.dockwidget:
-            self.dockwidget.projectLoaded.emit()
+            self.dockwidget.refresh_project_status()
 
     def _open_global_settings(self):
         """Ouvre la fenêtre de configuration globale du plugin."""
@@ -169,6 +194,12 @@ class Qsequoia2:
         QDesktopServices.openUrl(url)
  
     def unload(self):
+
+        try:
+            self.iface.projectRead.disconnect(self._schedule_project_status_refresh)
+            self.iface.newProjectCreated.disconnect(self._schedule_project_status_refresh)
+        except Exception:
+            pass
 
         # Remove actions
         for action in getattr(self, "actions", []):

--- a/qsequoia2/qsequoia2_dockwidget.py
+++ b/qsequoia2/qsequoia2_dockwidget.py
@@ -11,7 +11,7 @@ from qsequoia2.modules.add_data.add_data import AddDataTabWidget
 from qsequoia2.modules.layout_designer.layout_designer import LayoutDesignerWidget
 from qsequoia2.modules.forest_data.forest_data import ForestDataWidget
 from qsequoia2.modules.tools.tools import ToolsDialog
-from qsequoia2.modules.utils.variable import get_global_variable
+from qsequoia2.modules.utils.variable import get_global_variable, get_project_variable
 from qsequoia2.modules.utils.seq_config import *
 from qsequoia2.modules.utils.Qmessage import *
 from qsequoia2.modules.utils.configure_snapping import configure_snapping
@@ -176,6 +176,15 @@ class Qsequoia2DockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             self.lbl_forest_id.setText(fm.elidedText(label, Qt.ElideRight, 150))
             self.lbl_forest_id.setToolTip(label)
             self.lbl_forest_id.show()
+
+    def refresh_project_status(self):
+        seq_dir = get_project_variable("QS2_seq_dir")
+        seq_id = get_project_variable("QS2_seq_id")
+
+        if seq_dir and seq_id:
+            self._set_seq_dir_status(SeqDirState.VALID, str(seq_id))
+        else:
+            self._set_seq_dir_status(SeqDirState.EMPTY)
 
     def _init_tabs(self):
 


### PR DESCRIPTION
Salut @Balrog329,

Quelques modifs :

- J’ai essayé de réduire le nombre de crashs avec une meilleure gestion de l’ouverture/fermeture des projets.
- Le petit logo permettant d’indiquer si un dossier Sequoia2 est bien sélectionné se met désormais correctement à jour. Avant, si tu créais un projet manuellement par exemple, il indiquait que le dossier Sequoia2 était toujours sélectionné, même si ce n’était pas le cas.
- Petit fix pour le choix du format du layout. Il se trouve que QSequoia2 testait uniquement l’orientation portrait pour les dimensions, même si le layout était en paysage. Par exemple, pour une carte paysage nécessitant du 700 × 500, le format A1 = (594, 841) n’était pas retenu.